### PR TITLE
Fix NeoForge 1.21.9 (PrismLauncher#4190)

### DIFF
--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
@@ -1,5 +1,6 @@
 package io.github.zekerzhayard.forgewrapper.installer;
 
+import cpw.mods.modlauncher.ClassTransformer;
 import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -10,7 +11,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import cpw.mods.modlauncher.Launcher;
 import io.github.zekerzhayard.forgewrapper.installer.detector.DetectorLoader;
 import io.github.zekerzhayard.forgewrapper.installer.detector.IFileDetector;
 import io.github.zekerzhayard.forgewrapper.installer.util.ModuleUtil;
@@ -47,7 +47,7 @@ public class Main {
 
         try (URLClassLoader ucl = URLClassLoader.newInstance(new URL[] {
             Main.class.getProtectionDomain().getCodeSource().getLocation(),
-            Launcher.class.getProtectionDomain().getCodeSource().getLocation(),
+            ClassTransformer.class.getProtectionDomain().getCodeSource().getLocation(),
             installerJar.toUri().toURL()
         }, ModuleUtil.getPlatformClassLoader())) {
             Class<?> installer = ucl.loadClass("io.github.zekerzhayard.forgewrapper.installer.Installer");

--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/detector/IFileDetector.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/detector/IFileDetector.java
@@ -4,8 +4,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
-
-import cpw.mods.modlauncher.Launcher;
+import cpw.mods.modlauncher.ClassTransformer;
 
 public interface IFileDetector {
     /**
@@ -29,7 +28,7 @@ public interface IFileDetector {
             return Paths.get(libraryDir).toAbsolutePath();
         }
         try {
-            Path launcher = Paths.get(Launcher.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+            Path launcher = Paths.get(ClassTransformer.class.getProtectionDomain().getCodeSource().getLocation().toURI());
 
             while (!launcher.getFileName().toString().equals("libraries")) {
                 launcher = launcher.getParent();


### PR DESCRIPTION
This PR fixes NeoForge for all 1.21.9 versions [PrismLauncher#4190](https://github.com/PrismLauncher/PrismLauncher/issues/4190). It seems to be a bit buggy, but that could be on my part by the way I've tested the wrapper.